### PR TITLE
Dev/local development

### DIFF
--- a/roles/alacritty/files/alacritty.toml
+++ b/roles/alacritty/files/alacritty.toml
@@ -1,57 +1,3 @@
-live_config_reload = true
-
-[[colors.indexed_colors]]
-color = "0xcb4b16"
-index = 16
-
-[[colors.indexed_colors]]
-color = "0xd33682"
-index = 17
-
-[[colors.indexed_colors]]
-color = "0x073642"
-index = 18
-
-[[colors.indexed_colors]]
-color = "0x586e75"
-index = 19
-
-[[colors.indexed_colors]]
-color = "0x839496"
-index = 20
-
-[[colors.indexed_colors]]
-color = "0xeee8d5"
-index = 21
-
-[colors.bright]
-black = "0x657b83"
-blue = "0x268bd2"
-cyan = "0x2aa198"
-green = "0x859900"
-magenta = "0x6c71c4"
-red = "0xdc322f"
-white = "0xffffff"
-yellow = "0xb58900"
-
-[colors.cursor]
-cursor = "0xffffff"
-text = "0x002b36"
-
-[colors.normal]
-black = "0x002b36"
-blue = "0x268bd2"
-cyan = "0x2aa198"
-green = "0x859900"
-magenta = "0x6c71c4"
-red = "0xdc322f"
-white = "0xffffff"
-yellow = "0xb58900"
-
-[colors.primary]
-background = "0x002b36"
-foreground = "0xffffff"
-
 [env]
 TERM = "screen-256color"
 
@@ -163,7 +109,7 @@ save_to_clipboard = true
 
 [window]
 title = "Alacritty"
-opacity = 0.95
+opacity = 0.98
 dynamic_padding = true
 decorations = "None"
 startup_mode = "Maximized"
@@ -176,9 +122,6 @@ instance = "Alacritty"
 x = 1
 y = 0
 
-[shell]
-program = "/usr/bin/bash"
-
 [cursor]
 blink_interval = 500
 blink_timeout = 0
@@ -186,4 +129,8 @@ blink_timeout = 0
 [cursor.style]
 shape= "Block"
 blinking = "Always"
+
+[general]
+live_config_reload = true
+import = ["~/.config/alacritty/catppuccin-mocha.toml"]
 

--- a/roles/alacritty/files/catppuccin-mocha.toml
+++ b/roles/alacritty/files/catppuccin-mocha.toml
@@ -1,0 +1,65 @@
+[colors.primary]
+background = "#1e1e2e"
+foreground = "#cdd6f4"
+dim_foreground = "#7f849c"
+bright_foreground = "#cdd6f4"
+
+[colors.cursor]
+text = "#1e1e2e"
+cursor = "#f5e0dc"
+
+[colors.vi_mode_cursor]
+text = "#1e1e2e"
+cursor = "#b4befe"
+
+[colors.search.matches]
+foreground = "#1e1e2e"
+background = "#a6adc8"
+
+[colors.search.focused_match]
+foreground = "#1e1e2e"
+background = "#a6e3a1"
+
+[colors.footer_bar]
+foreground = "#1e1e2e"
+background = "#a6adc8"
+
+[colors.hints.start]
+foreground = "#1e1e2e"
+background = "#f9e2af"
+
+[colors.hints.end]
+foreground = "#1e1e2e"
+background = "#a6adc8"
+
+[colors.selection]
+text = "#1e1e2e"
+background = "#f5e0dc"
+
+[colors.normal]
+black = "#45475a"
+red = "#f38ba8"
+green = "#a6e3a1"
+yellow = "#f9e2af"
+blue = "#89b4fa"
+magenta = "#f5c2e7"
+cyan = "#94e2d5"
+white = "#bac2de"
+
+[colors.bright]
+black = "#585b70"
+red = "#f38ba8"
+green = "#a6e3a1"
+yellow = "#f9e2af"
+blue = "#89b4fa"
+magenta = "#f5c2e7"
+cyan = "#94e2d5"
+white = "#a6adc8"
+
+[[colors.indexed_colors]]
+index = 16
+color = "#fab387"
+
+[[colors.indexed_colors]]
+index = 17
+color = "#f5e0dc"

--- a/roles/alacritty/tasks/ubuntu.yml
+++ b/roles/alacritty/tasks/ubuntu.yml
@@ -75,8 +75,11 @@
 
 - name: Alacritty | Create symlink to Alacritty config
   ansible.builtin.file:
-    src: "{{ role_path }}/files/alacritty.toml"
-    dest: "{{ ansible_user_dir }}/.config/alacritty/alacritty.toml"
+    src: "{{ role_path }}/files/{{ item }}"
+    dest: "{{ ansible_user_dir }}/.config/alacritty/{{ item }}"
     state: link
     force: true
   become: true
+  loop:
+    - alacritty.toml
+    - catpuccin-mocha.toml

--- a/roles/bash/files/.bashrc
+++ b/roles/bash/files/.bashrc
@@ -106,3 +106,5 @@ case ":$PATH:" in
 esac
 
 # <<< juliaup initialize <<<
+
+source '/home/elidholm/.bash_completions/sb.py.sh'

--- a/roles/bash/files/bash/misc_aliases.sh
+++ b/roles/bash/files/bash/misc_aliases.sh
@@ -34,3 +34,4 @@ alias cls='clear'
 alias po="sudo shutdown now"
 alias rs="sudo reboot"
 
+alias sb="~/dev/sb-cli/src/sb.py"

--- a/roles/neovim/files/after/plugin/colors.lua
+++ b/roles/neovim/files/after/plugin/colors.lua
@@ -1,23 +1,10 @@
-require('solarized').setup({
-    transparent = {
-        enabled = true,
-    },
-    palette = 'selenized',
-    styles = {
-        comments = { italic = true, bold = false },
-    },
-    variant = 'spring',
-    plugins = {
-        lsp = true,
-        telescope = true,
-        treesitter = true,
-        cmp = true,
-    },
-    autocmd = true,
+require("catppuccin").setup({
+    flavour = "mocha", -- latte, frappe, macchiato, mocha
+    transparent_background = true,
 })
 
 function ColorMyPencils(color)
-	color = color or "solarized"
+	color = color or "catppuccin"
     vim.cmd.colorscheme(color)
 
 	vim.api.nvim_set_hl(0, "Normal", { bg = "none" })

--- a/roles/neovim/files/lua/edvin/packer.lua
+++ b/roles/neovim/files/lua/edvin/packer.lua
@@ -12,32 +12,7 @@ return require("packer").startup(function(use)
         requires = { { "nvim-lua/plenary.nvim" } }
     }
 
-    --use {
-    --    'lalitmee/cobalt2.nvim',
-    --    as = 'cobalt2',
-    --    requires = { { 'tjdevries/colorbuddy.nvim' } },
-    --}
-
-    --use({
-    --    'rose-pine/neovim',
-    --    as = 'rose-pine',
-    --    config = function()
-    --        vim.cmd('colorscheme rose-pine')
-    --    end
-    --})
-
-    use({
-        'maxmx03/solarized.nvim',
-        as = 'solarized',
-        config = function()
-            vim.o.background = 'dark' -- or 'light'
-            --@type solarized
-            local solarized = require('solarized')
-            vim.o.termguicolors = true
-            solarized.setup({})
-            vim.cmd.colorscheme 'solarized'
-        end
-    })
+    use { "catppuccin/nvim", as = "catppuccin" }
 
     use({
         "folke/trouble.nvim",

--- a/roles/starship/files/starship.toml
+++ b/roles/starship/files/starship.toml
@@ -1,125 +1,50 @@
-format = """
-[](#3B4252)\
-$username\
-[](bg:#434C5E fg:#3B4252)\
-$directory\
-[](fg:#434C5E bg:#4C566A)\
-$git_branch\
-$git_status\
-[](fg:#4C566A bg:#86BBD8)\
-$c\
-$elixir\
-$elm\
-$golang\
-$haskell\
-$java\
-$julia\
-$nodejs\
-$nim\
-$rust\
-[](fg:#86BBD8 bg:#06969A)\
-$docker_context\
-[](fg:#06969A bg:#33658A)\
-$time\
-[ ](fg:#33658A)\
-"""
-command_timeout = 5000
-# Disable the blank line at the start of the prompt
-# add_newline = false
+"$schema" = 'https://starship.rs/config-schema.json'
 
-# You can also replace your username with a neat symbol like  to save some space
+palette = "catppuccin_mocha"
+
 [username]
 show_always = true
-style_user = "bg:#3B4252"
-style_root = "bg:#3B4252"
 format = '[$user ]($style)'
 
+[git_branch]
+style = "bold mauve"
+
 [directory]
-style = "bg:#434C5E"
 format = "[ $path ]($style)"
 truncation_length = 3
 truncation_symbol = "…/"
+style = "bold lavender"
 
-# Here is how you can shorten some long paths by text replacement
-# similar to mapped_locations in Oh My Posh:
 [directory.substitutions]
 "Documents" = " "
 "Downloads" = " "
 "Music" = " "
 "Pictures" = " "
-# Keep in mind that the order matters. For example:
-# "Important Documents" = "  "
-# will not be replaced, because "Documents" was already substituted before.
-# So either put "Important Documents" before "Documents" or use the substituted version:
-# "Important  " = "  "
 
-[c]
-symbol = " "
-style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
-
-[docker_context]
-symbol = " "
-style = "bg:#06969A"
-format = '[ $symbol $context ]($style) $path'
-
-[elixir]
-symbol = " "
-style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
-
-[elm]
-symbol = " "
-style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
-
-[git_branch]
-symbol = ""
-style = "bg:#4C566A"
-format = '[ $symbol $branch ]($style)'
-
-[git_status]
-style = "bg:#4C566A"
-format = '[$all_status$ahead_behind ]($style)'
-
-[golang]
-symbol = " "
-style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
-
-[haskell]
-symbol = " "
-style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
-
-[java]
-symbol = " "
-style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
-
-[julia]
-symbol = " "
-style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
-
-[nodejs]
-disabled = true
-symbol = ""
-style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
-
-[nim]
-symbol = " "
-style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
-
-[rust]
-symbol = ""
-style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
-
-[time]
-disabled = false
-time_format = "%R" # Hour:Minute Format
-style = "bg:#33658A"
-format = '[ $time ]($style)'
+[palettes.catppuccin_mocha]
+rosewater = "#f5e0dc"
+flamingo = "#f2cdcd"
+pink = "#f5c2e7"
+mauve = "#cba6f7"
+red = "#f38ba8"
+maroon = "#eba0ac"
+peach = "#fab387"
+yellow = "#f9e2af"
+green = "#a6e3a1"
+teal = "#94e2d5"
+sky = "#89dceb"
+sapphire = "#74c7ec"
+blue = "#89b4fa"
+lavender = "#b4befe"
+text = "#cdd6f4"
+subtext1 = "#bac2de"
+subtext0 = "#a6adc8"
+overlay2 = "#9399b2"
+overlay1 = "#7f849c"
+overlay0 = "#6c7086"
+surface2 = "#585b70"
+surface1 = "#45475a"
+surface0 = "#313244"
+base = "#1e1e2e"
+mantle = "#181825"
+crust = "#11111b"

--- a/roles/tmux/files/.tmux.conf
+++ b/roles/tmux/files/.tmux.conf
@@ -51,19 +51,17 @@ set -g focus-events on
 set -g display-time 4000
 set -g status-interval 5
 set-option -g status-position 'bottom'
-set-option -g default-terminal 'screen-256color'
+set -g default-terminal 'tmux-256color'
 
 # Plugins (TPM: tmux plugin manager)
 set -g @plugin 'tmux-plugins/tpm'
-set -g @plugin 'christoomey/vim-tmux-navigator' # Vim-style pane navigation
 set -g @plugin 'tmux-plugins/tmux-yank'         # System clipboard integration
 set -g @plugin 'tmux-plugins/tmux-open'         # Open links/files from terminal
-set -g @plugin 'jimeh/tmux-themepack'           # Tmux themes
 set -g @plugin 'tmux-plugins/tmux-resurrect'    # Persist tmux session
 set -g @plugin 'tmux-plugins/tmux-continuum'    # Auto-save sessions
+set -g @plugin 'christoomey/vim-tmux-navigator' # Vim-style pane navigation
+set -g @plugin 'catppuccin/tmux'                # Catppuccin theme
 
-# Theme and visual appearance (customize as needed)
-set -g @themepack 'powerline/default/cyan'
 
 # Resurrect and Continuum configuration
 set -g @resurrect-capture-pane-contents 'on'
@@ -71,6 +69,23 @@ set -g @continuum-restore 'on'
 
 # Yank with mouse support
 set -g @yank_with_mouse on
+
+# Catppuccin theme configuration
+set -g @catppuccin_flavor 'mocha'
+set -g @catppuccin_window_status_style "rounded"
+set -g @catppuccin_window_text " #W"
+set -g @catppuccin_window_current_text " #W"
+
+# Load catppuccin
+run ~/.tmux/plugins/tmux/catppuccin.tmux
+
+# Make the status line pretty and add some modules
+set -g status-right-length 100
+set -g status-left-length 1000
+set -g status-left "#{E:@catppuccin_status_session}"
+set -g status-right "#{E:@catppuccin_status_host}"
+set -ag status-right "#{E:@catppuccin_status_date_time}"
+set -g @catppuccin_date_time_text " %H:%M"
 
 # TPM plugin initialization (Keep this at the bottom)
 run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified Catppuccin Mocha theme across Alacritty, Neovim, tmux, and Starship prompt.
  - Alacritty now supports live config reload and imports external theme; slight opacity increase.
  - Neovim defaults to Catppuccin with improved float transparency.
  - tmux adopts Catppuccin, 256-color term, and enhanced statusline modules.
  - Added sb alias and sourced bash completions.

- Style
  - Consolidated prompt theming via a shared Catppuccin palette, simplifying per-module styling.

- Chores
  - Symlink setup expanded to handle multiple configuration files automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->