### PR TITLE
chore(ci): disable pipeline execution on pushing to master

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,9 +1,6 @@
 ---
 name: Ansible CI
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,9 +1,6 @@
 ---
 name: Security Scanning
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified CI/CD workflow triggers: Linting and security scanning workflows will now only run on pull requests targeting the main branch, no longer running on direct pushes to the main branch. Security scanning continues to run on its scheduled interval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->