### PR TITLE
fix: ignore spaces before ':' in Python linting

### DIFF
--- a/roles/python/files/pycodestyle
+++ b/roles/python/files/pycodestyle
@@ -1,2 +1,3 @@
 [pycodestyle]
-max-line-length=119
+max-line-length = 119
+ignore = E203,W503


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pycodestyle configuration to modify code style validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->