### PR TITLE
fix(nvim): Correctly install nvim-treesitter

### DIFF
--- a/roles/neovim/files/init.lua
+++ b/roles/neovim/files/init.lua
@@ -591,18 +591,13 @@ do
 		vim.treesitter.start(buf, language)
 	end
 
-	local disabled_filetypes = {
-		"yaml",
-		"python",
-		"json",
-	}
 	local available_parsers = require("nvim-treesitter").get_available()
 	vim.api.nvim_create_autocmd("FileType", {
 		callback = function(args)
 			local buf, filetype = args.buf, args.match
 
 			local language = vim.treesitter.language.get_lang(filetype)
-			if not language or vim.tbl_contains(disabled_filetypes, filetype) then
+			if not language then
 				return
 			end
 

--- a/roles/neovim/files/nvim-pack-lock.json
+++ b/roles/neovim/files/nvim-pack-lock.json
@@ -26,10 +26,6 @@
       "rev": "a12fd5672110c8aa7e3c8419e28c96943ca179be",
       "src": "https://github.com/github/copilot.vim"
     },
-    "editorconfig.nvim": {
-      "rev": "67758c3e8a2f79019322a60013e4ce0aad09dafa",
-      "src": "https://github.com/gpanders/editorconfig.nvim"
-    },
     "fidget.nvim": {
       "rev": "82404b196e73a00b1727a91903beef5ddc319d22",
       "src": "https://github.com/j-hui/fidget.nvim"
@@ -122,10 +118,6 @@
     "todo-comments.nvim": {
       "rev": "31e3c38ce9b29781e4422fc0322eb0a21f4e8668",
       "src": "https://github.com/folke/todo-comments.nvim"
-    },
-    "tokyonight.nvim": {
-      "rev": "cdc07ac78467a233fd62c493de29a17e0cf2b2b6",
-      "src": "https://github.com/folke/tokyonight.nvim"
     },
     "trouble.nvim": {
       "rev": "bd67efe408d4816e25e8491cc5ad4088e708a69a",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Treesitter syntax highlighting attachment logic to better detect supported languages instead of using a blocklist approach.

* **Chores**
  * Removed editorconfig.nvim and tokyonight.nvim from managed plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->